### PR TITLE
Explicitly import libxml2.parser when needed

### DIFF
--- a/Foundation/Core/Parsers/PCKXMLParser.m
+++ b/Foundation/Core/Parsers/PCKXMLParser.m
@@ -1,6 +1,7 @@
 #import "PCKXMLParser.h"
 #import "PCKXMLParserDelegate.h"
 #import <libxml/tree.h>
+@import libxml2.parser;
 
 static xmlSAXHandler simpleSAXStruct;
 


### PR DESCRIPTION
When attempting to build this project from Xcode 9.3, the following
error was erupting:
```
$(SOURCE_ROOT)/PivotalCoreKit/Foundation/Core/Parsers/PCKXMLParser.m:5:22: error: definition of '_xmlSAXHandler' must be imported from module 'libxml2.parser' before it is required
static xmlSAXHandler simpleSAXStruct;
```

Adding `@import libxml2.parser` to the top of `PCKXMLParser.m` resolved
the issue.