### PR TITLE
Make UUIDWithLogging thread safe

### DIFF
--- a/Foundation/SpecHelper/Extensions/NSUUID+Spec.m
+++ b/Foundation/SpecHelper/Extensions/NSUUID+Spec.m
@@ -31,7 +31,9 @@ static NSMutableArray *uuids;
 
 + (NSUUID *)UUIDWithLogging {
     NSUUID *uuid = [self UUIDWithoutLogging];
-    [uuids addObject:uuid];
+    @synchronized(uuids) {
+        [uuids addObject:uuid];
+    }
 
     return uuid;
 }


### PR DESCRIPTION
When executing our specs we sometimes get crashes
when generating UUIDs by multiple threads in parallel
because of use of memory after free. This is because
`NSMutableArray` is not thread-safe.